### PR TITLE
Setting to customize Metadata URLs in sitemap

### DIFF
--- a/web-ui/src/main/resources/catalog/locales/en-admin.json
+++ b/web-ui/src/main/resources/catalog/locales/en-admin.json
@@ -833,6 +833,8 @@
     "system/server/protocol": "Preferred Protocol",
     "system/server/securePort": "Secure Port",
     "system/server/log": "Log level",
+    "system/server/sitemapLinkUrl": "Sitemap URL template",
+    "system/server/sitemapLinkUrl-help": "Template to build the links to medatada document in catalogue sitemap. String {{UUID}} will be replaced by the metadata UUID. For example, for the template http://www.example.com/external/metadata/html?uuid={{UUID}} the resulting URL in sitemap document would be http://www.example.com/external/metadata/html?uuid=this-is-the-actual-uuid",
     "system/site": "Catalog description",
     "system/site/name": "Catalog name",
     "system/site/name-help": "The name displayed in different places (eg. news feed).",

--- a/web/src/main/webapp/WEB-INF/classes/setup/sql/data/data-db-default.sql
+++ b/web/src/main/webapp/WEB-INF/classes/setup/sql/data/data-db-default.sql
@@ -562,6 +562,7 @@ INSERT INTO Settings (name, value, datatype, position, internal) VALUES ('system
 INSERT INTO Settings (name, value, datatype, position, internal) VALUES ('system/server/port', '8080', 1, 230, 'n');
 INSERT INTO Settings (name, value, datatype, position, internal) VALUES ('system/server/securePort', '8443', 1, 240, 'y');
 INSERT INTO settings (name, value, datatype, position, internal) VALUES ('system/server/log','log4j.xml',0,250,'y');
+INSERT INTO Settings (name, value, datatype, position, internal) VALUES ('system/server/sitemapLinkUrl', NULL, 0, 260, 'y');
 INSERT INTO Settings (name, value, datatype, position, internal) VALUES ('system/intranet/network', '127.0.0.1', 0, 310, 'y');
 INSERT INTO Settings (name, value, datatype, position, internal) VALUES ('system/intranet/netmask', '255.0.0.0', 0, 320, 'y');
 INSERT INTO Settings (name, value, datatype, position, internal) VALUES ('system/proxy/use', 'false', 2, 510, 'y');

--- a/web/src/main/webapp/WEB-INF/classes/setup/sql/migrate/v310/migrate-sitemap-default.sql
+++ b/web/src/main/webapp/WEB-INF/classes/setup/sql/migrate/v310/migrate-sitemap-default.sql
@@ -1,0 +1,2 @@
+INSERT INTO Settings (name, value, datatype, position, internal) VALUES ('system/server/sitemapLinkUrl', NULL, 0, 260, 'y');
+

--- a/web/src/main/webapp/WEB-INF/config-db/database_migration.xml
+++ b/web/src/main/webapp/WEB-INF/config-db/database_migration.xml
@@ -159,6 +159,7 @@
       <list>
         <value>java:org.fao.geonet.api.records.attachments.MetadataResourceDatabaseMigration</value>
         <value>WEB-INF/classes/setup/sql/migrate/v310/migrate-</value>
+        <value>WEB-INF/classes/setup/sql/migrate/v310/migrate-sitemap-</value>
       </list>
     </entry>
   </util:map>

--- a/web/src/main/webapp/xslt/services/sitemap/sitemap.xsl
+++ b/web/src/main/webapp/xslt/services/sitemap/sitemap.xsl
@@ -133,10 +133,16 @@
               </xsl:when>
 
               <xsl:otherwise>
-                <xsl:value-of select="$env/system/server/protocol"/>://<xsl:value-of
-                select="$env/system/server/host"/>:<xsl:value-of
-                select="$env/system/server/port"/><xsl:value-of select="/root/gui/url"/>/?uuid=<xsl:value-of
-                select="$uuid"/>
+                <xsl:variable name="metadataUrl">
+                  <xsl:choose>
+                    <xsl:when test="contains(upper-case(normalize-space($env/system/server/sitemapLinkUrl)), '{{UUID}}')"><xsl:value-of select="replace($env/system/server/sitemapLinkUrl, '\{\{UUID\}\}', $uuid, 'i' )"/></xsl:when>
+                    <xsl:otherwise><xsl:value-of select="$env/system/server/protocol"/>://<xsl:value-of
+                      select="$env/system/server/host"/>:<xsl:value-of
+                      select="$env/system/server/port"/><xsl:value-of select="/root/gui/url"/>/?uuid=<xsl:value-of
+                      select="$uuid"/></xsl:otherwise>
+                  </xsl:choose>
+                </xsl:variable>
+                <xsl:value-of select="$metadataUrl"/>
               </xsl:otherwise>
             </xsl:choose>
           </loc>


### PR DESCRIPTION
Add a new setting `system/server/sitemapLinkUrl` to customize the HTML links to the
metadata documents in sitemap service. Customized URLs must include the pattern `{{UUID}}` that . will be replaced by the actual metadata UUID. If the setting is empty or not present GN default value for the URL will be used.