### PR TITLE
Hide the groups dropdown when there's only one group

### DIFF
--- a/se-web-ui/src/main/resources/catalog/views/swe/templates/index.html
+++ b/se-web-ui/src/main/resources/catalog/views/swe/templates/index.html
@@ -142,7 +142,7 @@
                     </label>
                   </div>
 
-                  <div class="row" data-ng-show="groups && groups.length > 0">
+                  <div class="row" data-ng-show="groups && groups.length > 1">
                     <label class="control-label ngr-md-label">
                       <span data-translate="">createMetadata-group</span>:
 


### PR DESCRIPTION
When creating a new metadata record the group-selection should not be needed in case user only have privilege in a single group.

![metagis-md-groups](https://user-images.githubusercontent.com/19608667/66992196-b35fbf00-f0c9-11e9-8e43-c13f85dbacc1.png)
