### PR TITLE
Empty / placeholder - maintenance frequency (#6399)

### DIFF
--- a/schemas/iso19139.swe/src/main/plugin/iso19139.swe/inflate-metadata.xsl
+++ b/schemas/iso19139.swe/src/main/plugin/iso19139.swe/inflate-metadata.xsl
@@ -255,7 +255,22 @@
         </gmd:pointOfContact>
       </xsl:if>
 
+      <!-- Add a resource maintenance element if there isn't any -->
       <xsl:apply-templates select="gmd:resourceMaintenance" />
+      <xsl:if test="not(gmd:resourceMaintenance)">
+        <gmd:resourceMaintenance>
+          <gmd:MD_MaintenanceInformation>
+            <gmd:maintenanceAndUpdateFrequency>
+              <gmd:MD_MaintenanceFrequencyCode
+                codeList="http://standards.iso.org/ittf/PubliclyAvailableStandards/ISO_19139_Schemas/resources/codelist/ML_gmxCodelists.xml#MD_MaintenanceFrequencyCode"
+                codeListValue=""></gmd:MD_MaintenanceFrequencyCode>
+            </gmd:maintenanceAndUpdateFrequency>
+          </gmd:MD_MaintenanceInformation>
+        </gmd:resourceMaintenance>
+        <gmd:maintenanceNote>
+            <gco:CharacterString></gco:CharacterString>
+        </gmd:maintenanceNote>
+      </xsl:if>
 
       <!-- Process graphic overview -->
       <xsl:for-each select="gmd:graphicOverview">
@@ -1016,7 +1031,23 @@
       <xsl:apply-templates select="gmd:credit" />
       <xsl:apply-templates select="gmd:status" />
       <xsl:apply-templates select="gmd:pointOfContact" />
+
+      <!-- Add a resource maintenance element if there isn't any -->
       <xsl:apply-templates select="gmd:resourceMaintenance" />
+      <xsl:if test="not(gmd:resourceMaintenance)">
+        <gmd:resourceMaintenance>
+          <gmd:MD_MaintenanceInformation>
+            <gmd:maintenanceAndUpdateFrequency>
+              <gmd:MD_MaintenanceFrequencyCode
+                codeList="http://standards.iso.org/ittf/PubliclyAvailableStandards/ISO_19139_Schemas/resources/codelist/ML_gmxCodelists.xml#MD_MaintenanceFrequencyCode"
+                codeListValue=""></gmd:MD_MaintenanceFrequencyCode>
+            </gmd:maintenanceAndUpdateFrequency>
+          </gmd:MD_MaintenanceInformation>
+        </gmd:resourceMaintenance>
+        <gmd:maintenanceNote>
+          <gco:CharacterString></gco:CharacterString>
+        </gmd:maintenanceNote>
+      </xsl:if>
 
       <!-- Process graphic overview -->
       <xsl:for-each select="gmd:graphicOverview">

--- a/schemas/iso19139.swe/src/main/plugin/iso19139.swe/present/csw/gmd-csw-inspire-postprocessing.xsl
+++ b/schemas/iso19139.swe/src/main/plugin/iso19139.swe/present/csw/gmd-csw-inspire-postprocessing.xsl
@@ -747,4 +747,33 @@
       </xsl:copy>
     </xsl:if>
   </xsl:template>
+
+	<xsl:template match="gmd:resourceMaintenance">
+		<xsl:choose>
+			<!-- Remove gmd:resourceMaintenance if placeholder of empty -->
+			<xsl:when test="gmd:MD_MaintenanceInformation/gmd:maintenanceAndUpdateFrequency/gmd:MD_MaintenanceFrequencyCode[not(@codeListValue) or @codeListValue='' or @codeListValue='{{maintenance_frequency}}']">
+			</xsl:when>
+			<xsl:otherwise>
+				<xsl:copy>
+					<xsl:apply-templates select="@*|node()" mode="resourceMaintenance"/>
+				</xsl:copy>
+			</xsl:otherwise>
+		</xsl:choose>
+	</xsl:template>
+	<xsl:template match="gmd:maintenanceNote" mode="resourceMaintenance">
+		<xsl:choose>
+			<xsl:when test="string-length(normalize-space(gco:CharacterString))=0
+				or normalize-space(gco:CharacterString)='{{maintenance_note}}'">
+			</xsl:when>
+			<xsl:otherwise>
+				<xsl:copy>
+					<xsl:apply-templates select="@*|node()"/>
+				</xsl:copy></xsl:otherwise>
+		</xsl:choose>
+	</xsl:template>
+	<xsl:template match="@*|node()" mode="resourceMaintenance">
+		<xsl:copy>
+			<xsl:apply-templates select="@*|node()" mode="resourceMaintenance"/>
+		</xsl:copy>
+	</xsl:template>
 </xsl:stylesheet>

--- a/schemas/iso19139.swe/src/main/plugin/iso19139.swe/present/csw/gmd-csw-inspire-swe-postprocessing.xsl
+++ b/schemas/iso19139.swe/src/main/plugin/iso19139.swe/present/csw/gmd-csw-inspire-swe-postprocessing.xsl
@@ -746,4 +746,33 @@
       </xsl:copy>
     </xsl:if>
   </xsl:template>
+
+  <xsl:template match="gmd:resourceMaintenance">
+    <xsl:choose>
+      <!-- Remove gmd:resourceMaintenance if placeholder of empty -->
+    	<xsl:when test="gmd:MD_MaintenanceInformation/gmd:maintenanceAndUpdateFrequency/gmd:MD_MaintenanceFrequencyCode[not(@codeListValue) or @codeListValue='' or @codeListValue='{{maintenance_frequency}}']">
+      </xsl:when>
+      <xsl:otherwise>
+        <xsl:copy>
+          <xsl:apply-templates select="@*|node()" mode="resourceMaintenance"/>
+        </xsl:copy>
+      </xsl:otherwise>
+    </xsl:choose>
+  </xsl:template>
+  <xsl:template match="gmd:maintenanceNote" mode="resourceMaintenance">
+    <xsl:choose>
+      <xsl:when test="string-length(normalize-space(gco:CharacterString))=0
+				or normalize-space(gco:CharacterString)='{{maintenance_note}}'">
+      </xsl:when>
+      <xsl:otherwise>
+        <xsl:copy>
+          <xsl:apply-templates select="@*|node()"/>
+        </xsl:copy></xsl:otherwise>
+    </xsl:choose>
+  </xsl:template>
+  <xsl:template match="@*|node()" mode="resourceMaintenance">
+    <xsl:copy>
+      <xsl:apply-templates select="@*|node()" mode="resourceMaintenance"/>
+    </xsl:copy>
+  </xsl:template>
 </xsl:stylesheet>

--- a/schemas/iso19139.swe/src/main/plugin/iso19139.swe/update-fixed-info.xsl
+++ b/schemas/iso19139.swe/src/main/plugin/iso19139.swe/update-fixed-info.xsl
@@ -900,6 +900,24 @@
     </gmd:role>
   </xsl:template>
 
+
+  <!-- if a gmd:ResourceMaintenance doesn't contain info (no codelist for MD_MaintenanceFrequencyCode and empty gmd:maintenanceNote, remove it
+	-->
+  <xsl:template match="gmd:resourceMaintenance">
+    <xsl:choose>
+      <!-- Remove gmd:resourceMaintenance if empty -->
+      <xsl:when test="gmd:MD_MaintenanceInformation/gmd:maintenanceAndUpdateFrequency/gmd:MD_MaintenanceFrequencyCode[@codeListValue='' or not(codeListValue)]
+        and string-length(normalize-space(gmd:MD_MaintenanceInformation/gmd:maintenanceNote/gco:CharacterString))=0">
+      </xsl:when>
+      <xsl:otherwise>
+        <xsl:copy>
+          <xsl:apply-templates select="@*|node()"/>
+        </xsl:copy>
+      </xsl:otherwise>
+    </xsl:choose>
+  </xsl:template>
+
+
 <!-- ================================================================= -->
 	<!-- copy everything else as is -->
 

--- a/schemas/iso19139.swe/src/main/plugin/iso19139.swe/update-fixed-info.xsl
+++ b/schemas/iso19139.swe/src/main/plugin/iso19139.swe/update-fixed-info.xsl
@@ -579,17 +579,17 @@
   <xsl:template match="gmd:DQ_Scope">
     <xsl:copy>
       <xsl:copy-of select="@*" />
-      
+
       <gmd:level>
         <gmd:MD_ScopeCode codeListValue="{//gmd:hierarchyLevel[1]/gmd:MD_ScopeCode/@codeListValue}"
           codeList="http://standards.iso.org/ittf/PubliclyAvailableStandards/ISO_19139_Schemas/resources/codelist/ML_gmxCodelists.xml#MD_ScopeCode"/>
       </gmd:level>
-      
+
       <xsl:apply-templates select="gmd:extent" />
       <xsl:apply-templates select="gmd:levelDescription" />
     </xsl:copy>
   </xsl:template>
-  
+
 	<xsl:template match="gmd:identificationInfo/gmd:MD_DataIdentification">
 		<xsl:copy>
 			<xsl:copy-of select="@*" />
@@ -906,7 +906,7 @@
   <xsl:template match="gmd:resourceMaintenance">
     <xsl:choose>
       <!-- Remove gmd:resourceMaintenance if empty -->
-      <xsl:when test="gmd:MD_MaintenanceInformation/gmd:maintenanceAndUpdateFrequency/gmd:MD_MaintenanceFrequencyCode[@codeListValue='' or not(codeListValue)]
+      <xsl:when test="gmd:MD_MaintenanceInformation/gmd:maintenanceAndUpdateFrequency/gmd:MD_MaintenanceFrequencyCode[@codeListValue='' or not(@codeListValue)]
         and string-length(normalize-space(gmd:MD_MaintenanceInformation/gmd:maintenanceNote/gco:CharacterString))=0">
       </xsl:when>
       <xsl:otherwise>


### PR DESCRIPTION
* Remove `gmd:resourceMaintenance` if contains a `gmd:MD_MaintenanceFrequencyCode`
with `codeListValue` empty or with placeholder `{{{{maintenance_frequency}}`
* Inside `gmd:resourceMaintenance` remove empty `gmd:maintenanceNote` or if it is
equals to placeholder `{{maintenance_note}}`.
* If a gmd:ResourceMaintenance doesn't contain info (no codelist for `gmd:MD_MaintenanceFrequencyCode`
and empty `gmd:maintenanceNote`), remove it on save event (update-fixed-info.xsl).
* Manage add `gmd:resourceMaintenance` there isn't any in inflate-metadata.xsl.